### PR TITLE
simplify instructions to install seaclouds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nohup.out
 *.log
 .vagrant
+.idea

--- a/README.md
+++ b/README.md
@@ -9,28 +9,32 @@ A deployment of SeaClouds can be launched using Apache Brooklyn. We currently su
 
 ## Launching with Vagrant
 
-Make sure you have [Vagrant](https://www.vagrantup.com/), [Virtual Box](https://www.virtualbox.org/) and [Apache Brooklyn](https://brooklyn.incubator.apache.org/download/index.html) installed, then:
+Make sure you have [Vagrant](https://www.vagrantup.com/), [Virtual Box](https://www.virtualbox.org/)
 
 ```bash
 cd $HOME
 git clone git@github.com:SeaCloudsEU/seaclouds-distribution.git
 cd seaclouds-distribution
-./setup
-```
-Please make sure you have configured BROOKLYN_HOME at least in the current terminal.
-
-```bash
 vagrant up
 ```
 This spins up a virtual environment, made up of 2 VMs, that is accessible at `192.168.100.10` and `192.168.100.11`.
 
-Start Apache Brooklyn
+## Download and install Brooklyn MODAClouds distribution
+
 ```bash
-nohup $BROOKLYN_HOME/bin/brooklyn launch &
+cd $HOME
+wget -q -O brooklyn-modaclouds-dist.tar.gz "http://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=brooklyn-modaclouds&v=LATEST&c=dist&p=tar.gz" --content-disposition
+tar xzf brooklyn-modaclouds-dist.tar.gz
+cd brooklyn-modaclouds
+./start.sh launch
 ```
-This starts up your instance of [Apache Brooklyn](http://brooklyn.io) on your workstation, accesible at http://localhost:8081. 
+
+This starts up your instance of [Apache Brooklyn](http://brooklyn.io) on your workstation, accesible at http://localhost:8081.
 Please double-check in nohup.out the correct url.
 
-Finally, copy and paste [seaclouds blueprint](seaclouds.yaml) to deploy the SeaClouds platform on the 2 VMs.
+Finally, copy and paste [seaclouds blueprint](seaclouds-on-byon.yaml) to deploy the SeaClouds platform on the 2 VMs.
 
-You should update the privateKeyFile property in the blueprint to the actual path. If you run setup.sh, the property will be updated for you.
+You may need to update the `privateKeyFile` property in the blueprint to the actual path.
+By default, it points to `~/seaclouds-distribution/seaclouds_id_rsa`  but YMMV.
+
+For more information, please visit [Apache Brooklyn](https://brooklyn.incubator.apache.org/download/index.html)

--- a/seaclouds-on-byon.yaml
+++ b/seaclouds-on-byon.yaml
@@ -1,0 +1,63 @@
+name: SeaClouds platform
+
+location:
+  byon:
+    user: vagrant
+    privateKeyFile: ~/seaclouds-distribution/seaclouds_id_rsa
+    hosts:
+    - 192.168.100.10
+    - 192.168.100.11
+
+services:
+- serviceType: brooklyn.entity.basic.SameServerEntity
+  name: SeaClouds Deployer + Monitoring 
+  brooklyn.children:
+  - serviceType: "classpath://brooklyn/entity/modaclouds/modaclouds.yaml"
+    id: monitoring
+    name: SeaClouds Monitoring
+  - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
+    id: deployer
+    name: SeaClouds Deployer
+    install.version: 0.7.0-SNAPSHOT
+    managementUser: admin
+    managementPassword: p4ssw0rd
+    brooklynLocalPropertiesContents: |
+      brooklyn.webconsole.security.users=admin
+      brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+
+- serviceType: brooklyn.entity.basic.SameServerEntity
+  name: SeaClouds Dashboard + Planner + SLA
+  brooklyn.children:
+  - serviceType: brooklyn.entity.webapp.jetty.Jetty6Server
+    name: SeaClouds Dashboard 
+    id: dashboard
+    httpPort: 8000
+    war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=dashboard&v=LATEST&e=war
+    launch.latch: $brooklyn:component("deployer").attributeWhenReady("service.isUp")
+    brooklyn.config:
+      java.sysprops:
+        deployer.host: $brooklyn:component("deployer").attributeWhenReady("host.address")
+        deployer.httpPort: $brooklyn:component("deployer").attributeWhenReady("brooklynnode.webconsole.httpPort")
+        deployer.username: $brooklyn:component("deployer").config("brooklynnode.managementUser")
+        deployer.password: $brooklyn:component("deployer").config("brooklynnode.managementPassword")
+  - serviceType: brooklyn.entity.basic.SameServerEntity
+    name: SeaClouds SLA
+    brooklyn.children:
+    - serviceType: brooklyn.entity.webapp.tomcat.TomcatServer
+      name: SLA Core
+      id: sla-core
+      brooklyn.config:
+        java.sysprops:
+            DB_URL: >
+                $brooklyn:formatString("jdbc:%s%s",
+                component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
+            DB_USERNAME: "atossla"
+            DB_PASSWORD: "_atossla_"
+      war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
+
+
+    - serviceType: brooklyn.entity.database.mysql.MySqlNode
+      id: sla-db
+      name: SLA Db
+      brooklyn.config:
+        creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql

--- a/seaclouds.yaml
+++ b/seaclouds.yaml
@@ -1,63 +1,50 @@
 name: SeaClouds platform
 
-location:
-  byon:
-    user: vagrant
-    privateKeyFile: ~/git/seaclouds/seaclouds-distribution/seaclouds_id_rsa
-    hosts:
-    - 192.168.100.10
-    - 192.168.100.11
+# specify a location
+# location:
 
 services:
-- serviceType: brooklyn.entity.basic.SameServerEntity
-  name: SeaClouds Deployer + Monitoring 
-  brooklyn.children:
-  - serviceType: "classpath://brooklyn/entity/modaclouds/modaclouds.yaml"
-    id: monitoring
-    name: SeaClouds Monitoring
-  - serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
-    id: deployer
-    name: SeaClouds Deployer
-    install.version: 0.7.0-SNAPSHOT
-    managementUser: admin
-    managementPassword: p4ssw0rd
-    brooklynLocalPropertiesContents: |
-      brooklyn.webconsole.security.users=admin
-      brooklyn.webconsole.security.user.admin.password=p4ssw0rd
+- serviceType: "classpath://brooklyn/entity/modaclouds/modaclouds.yaml"
+  id: monitoring
+  name: SeaClouds Monitoring
+- serviceType: "classpath://brooklyn/entity/brooklynnode/brooklyn-node.yaml"
+  id: deployer
+  name: SeaClouds Deployer
+  install.version: 0.7.0-SNAPSHOT
+  managementUser: admin
+  managementPassword: p4ssw0rd
+  brooklynLocalPropertiesContents: |
+    brooklyn.webconsole.security.users=admin
+    brooklyn.webconsole.security.user.admin.password=p4ssw0rd
 
+- serviceType: brooklyn.entity.webapp.jetty.Jetty6Server
+  name: SeaClouds Dashboard
+  id: dashboard
+  httpPort: 8000
+  war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=dashboard&v=LATEST&e=war
+  launch.latch: $brooklyn:component("deployer").attributeWhenReady("service.isUp")
+  brooklyn.config:
+    java.sysprops:
+      deployer.host: $brooklyn:component("deployer").attributeWhenReady("host.address")
+      deployer.httpPort: $brooklyn:component("deployer").attributeWhenReady("brooklynnode.webconsole.httpPort")
+      deployer.username: $brooklyn:component("deployer").config("brooklynnode.managementUser")
+      deployer.password: $brooklyn:component("deployer").config("brooklynnode.managementPassword")
 - serviceType: brooklyn.entity.basic.SameServerEntity
-  name: SeaClouds Dashboard + Planner + SLA
+  name: SeaClouds SLA
   brooklyn.children:
-  - serviceType: brooklyn.entity.webapp.jetty.Jetty6Server
-    name: SeaClouds Dashboard 
-    id: dashboard
-    httpPort: 8000
-    war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=dashboard&v=LATEST&e=war
-    launch.latch: $brooklyn:component("deployer").attributeWhenReady("service.isUp")
+  - serviceType: brooklyn.entity.webapp.tomcat.TomcatServer
+    name: SLA Core
+    id: sla-core
     brooklyn.config:
       java.sysprops:
-        deployer.host: $brooklyn:component("deployer").attributeWhenReady("host.address")
-        deployer.httpPort: $brooklyn:component("deployer").attributeWhenReady("brooklynnode.webconsole.httpPort")
-        deployer.username: $brooklyn:component("deployer").config("brooklynnode.managementUser")
-        deployer.password: $brooklyn:component("deployer").config("brooklynnode.managementPassword")
-  - serviceType: brooklyn.entity.basic.SameServerEntity
-    name: SeaClouds SLA
-    brooklyn.children:
-    - serviceType: brooklyn.entity.webapp.tomcat.TomcatServer
-      name: SLA Core
-      id: sla-core
-      brooklyn.config:
-        java.sysprops:
-            DB_URL: >
-                $brooklyn:formatString("jdbc:%s%s",
-                component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
-            DB_USERNAME: "atossla"
-            DB_PASSWORD: "_atossla_"
-      war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
-
-
-    - serviceType: brooklyn.entity.database.mysql.MySqlNode
-      id: sla-db
-      name: SLA Db
-      brooklyn.config:
-        creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql
+          DB_URL: >
+              $brooklyn:formatString("jdbc:%s%s",
+              component("sla-db").attributeWhenReady("datastore.url"), "sc_sla")
+          DB_USERNAME: "atossla"
+          DB_PASSWORD: "_atossla_"
+    war: https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=eu.seaclouds-project&a=sla-service&v=LATEST&e=war
+  - serviceType: brooklyn.entity.database.mysql.MySqlNode
+    id: sla-db
+    name: SLA Db
+    brooklyn.config:
+      creationScriptUrl: https://raw.githubusercontent.com/SeaCloudsEU/sla-core/e1d3bd4dec27236cfdefa1eae81d38db3dcd11da/sla-repository/src/main/resources/sql/01database.sql


### PR DESCRIPTION
- it doesn't require the user to pre-install brooklyn manually
- add blueprint `seaclouds.yaml` to deploy  on a cloud
- rename `seaclouds.yaml` to `seaclouds-on-byon.yaml`
